### PR TITLE
Update error.c

### DIFF
--- a/error.c
+++ b/error.c
@@ -10,7 +10,7 @@ void merge(int arr[], int l, int m, int r) {
     for(int i=0;i<n1;i++)
         L[i] = arr[l + i];
     for(int j=0;j<n2;j++)
-        R[j] = arr[j]; 
+        R[j] = arr[m+j+1]; 
 
     int i=0,j=0,k=l;
     while(i<n1 && j<n2) {


### PR DESCRIPTION
Fix right subarray copy in merge()

Changed `R[j] = arr[j];` to `R[j] = arr[m + 1 + j];` to correctly copy
elements from the right half (arr[m+1..r]) instead of from index 0.
